### PR TITLE
Add support to use `docker` driver on host machine

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -79,9 +79,9 @@ export class DockerSocketProxy {
    * @returns
    */
   async #onUpgradeRequest(req, socket, head) {
-    const upgrade = (req.headers['upgrade'] || '').toLowerCase();
-    const tokens = upgrade.split(',').map(s => s.trim());
-    if (!tokens.includes('tcp') && !tokens.includes('h2c')) {
+    const upgrade = (req.headers["upgrade"] || "").toLowerCase();
+    const tokens = upgrade.split(",").map((s) => s.trim());
+    if (!tokens.includes("tcp") && !tokens.includes("h2c")) {
       console.log(`[UPGRADE REQUEST] ${req.url} - denied`);
       socket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
       socket.destroy();
@@ -95,7 +95,8 @@ export class DockerSocketProxy {
 
     const headers = { ...req.headers };
     if (headers["x-docker-expose-session-grpc-method"]) {
-      headers["x-docker-expose-session-grpc-method"] = headers["x-docker-expose-session-grpc-method"].split(", ");
+      headers["x-docker-expose-session-grpc-method"] =
+        headers["x-docker-expose-session-grpc-method"].split(", ");
     }
 
     const proxyReqOptions = {
@@ -108,7 +109,7 @@ export class DockerSocketProxy {
       proxyReqOptions.port = this.forwardPath;
     } else {
       proxyReqOptions.socketPath = this.forwardPath;
-    }    
+    }
 
     const proxyReq = http.request(proxyReqOptions);
 
@@ -131,13 +132,15 @@ export class DockerSocketProxy {
             res.headers,
           ),
         );
-        res.on('error', () => socket.end());
+        res.on("error", () => socket.end());
         res.pipe(socket);
       }
     });
 
     proxyReq.on("upgrade", function (proxyRes, proxySocket, proxyHead) {
-      socket.write(createHttpHeader("HTTP/1.1 101 Switching Protocols", proxyRes.headers));
+      socket.write(
+        createHttpHeader("HTTP/1.1 101 Switching Protocols", proxyRes.headers),
+      );
 
       if (head && head.length) proxySocket.write(head);
       if (proxyHead && proxyHead.length) socket.write(proxyHead);


### PR DESCRIPTION
This PR adds the ability to use the `docker` driver on the host machine. There were a few things needed in order to pull this off:

1. Buildx performs a few upgrade requests using `h2c` instead of `tcp`. Previously, we were only allowing `tcp` upgrades. This changes that.

2. When forwarding the request, Node collapses repeated headers into a single header with comma-separated values. While the RFC technically allows this, the BuildKit code is expecting multiple headers.

    Instead of sending:

    ```
    X-Docker-Expose-Session-Grpc-Method: /moby.filesync.v1.Auth/GetTokenAuthority
    X-Docker-Expose-Session-Grpc-Method: /moby.filesync.v1.Auth/VerifyTokenAuthority
    X-Docker-Expose-Session-Grpc-Method: /moby.filesync.v1.Auth/Credentials
    X-Docker-Expose-Session-Grpc-Method: /moby.filesync.v1.Auth/FetchToken
    X-Docker-Expose-Session-Grpc-Method: /moby.buildkit.secrets.v1.Secrets/GetSecret
    X-Docker-Expose-Session-Grpc-Method: /moby.sshforward.v1.SSH/CheckAgent
    X-Docker-Expose-Session-Grpc-Method: /moby.sshforward.v1.SSH/ForwardAgent
    X-Docker-Expose-Session-Grpc-Method: /grpc.health.v1.Health/List
    X-Docker-Expose-Session-Grpc-Method: /grpc.health.v1.Health/Check
    X-Docker-Expose-Session-Grpc-Method: /grpc.health.v1.Health/Watch
    X-Docker-Expose-Session-Grpc-Method: /moby.filesync.v1.FileSync/DiffCopy
    X-Docker-Expose-Session-Grpc-Method: /moby.filesync.v1.FileSync/TarStream
    ```

    The proxy was sending:

    ```
    x-docker-expose-session-grpc-method: /moby.filesync.v1.Auth/Credentials, /moby.filesync.v1.Auth/FetchToken, /moby.filesync.v1.Auth/GetTokenAuthority, /moby.filesync.v1.Auth/VerifyTokenAuthority, /moby.buildkit.secrets.v1.Secrets/GetSecret, /moby.sshforward.v1.SSH/CheckAgent, /moby.sshforward.v1.SSH/ForwardAgent, /grpc.health.v1.Health/Check, /grpc.health.v1.Health/List, /grpc.health.v1.Health/Watch, /moby.filesync.v1.FileSync/DiffCopy, /moby.filesync.v1.FileSync/TarStream
    ```

    This PR specifically looks for this header and splits it back into an array.

In addition, this PR adds the ability to forward to a Docker engine API exposed via a TCP port to enable further debugging (Wireshark is what helped catch the header difference).